### PR TITLE
urlParser.resolve requires urls to be strings

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1368,8 +1368,9 @@ Parser.prototype = {
 							out[item] = [];
 						}
 
-
-						out[item].push( urlParser.resolve(this.options.baseUrl, value) );
+						if(typeof this.options.baseUrl == 'string' && typeof value === 'string') {
+							out[item].push( urlParser.resolve(this.options.baseUrl, value) );
+						}
 						z++;
 					}
 				}


### PR DESCRIPTION
In some instances the url or this.options.baseUrl are objects or null, this protects against url.js from throwing an error.
