### PR TITLE
Resolve implied URL to an absolute URL

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -623,6 +623,10 @@ Parser.prototype = {
 			if(!uf.properties.url) {
 				value = domUtils.getAttrValFromTagList(dom, node, ['a'], 'href');
 				if(value) {
+					// relative to absolute URL
+					if(value !== '' && this.options.baseUrl !== '' && value.indexOf(':') === -1) {
+						value = urlParser.resolve(this.options.baseUrl, value);
+					}
 					uf.properties.url = [utils.trim(value)];
 				}
 			}


### PR DESCRIPTION
Just like an implied photo is resolved to an absolute URL an implied URL should be resolved to one, so I copied the solution from photos and applied it to the implied URL:s as well.

Also double checked at http://microformats.org/wiki/microformats2-parsing#parsing_for_implied_properties that this is how it should be parsed.

Also have to say: Thanks for a great Node.js library! Likely wouldn't have done at all as much IndieWeb stuff without it lowering the barrier.