### PR TITLE
Experimental language parsing

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -718,6 +718,11 @@ Parser.prototype = {
 		}
 		delete uf.altValue;
 
+		value = domUtils.getAttribute(dom, node, 'lang');
+		if (value) {
+			uf.lang = value;
+		}
+
 	},
 	
 	
@@ -965,6 +970,11 @@ Parser.prototype = {
 		out.value = text.parse(dom, node, this.options.textFormat);
 		//out.html = domUtils.innerHTML(dom, node);
 		out.html = html.parse(dom, node);
+
+		var lang = domUtils.getAttribute(dom, node, 'lang');
+		if (lang) {
+			out.lang = lang;
+		}
 
 		return out;
 	},

--- a/test/mf-v2-h-entry-lang.js
+++ b/test/mf-v2-h-entry-lang.js
@@ -1,0 +1,20 @@
+/*
+Microformats Test Suite - Downloaded from github repo: glennjones/tests version v0.1.17 
+Mocha integration test from: microformats-v2/h-entry/justaname
+The test was built on Sun Jun 14 2015 10:55:15 GMT+0100 (BST)
+*/
+
+var chai = require('chai'),
+   assert = chai.assert,
+   helper = require('../test/helper.js');
+
+
+describe('h-entry', function() {
+   var htmlFragment = "<p class=\"h-entry\" lang=\"se\"><div class=\"e-content\" lang=\"en\">microformats.org at 7</div></p>";
+   var found = helper.parseHTML(htmlFragment,'http://example.com/');
+   var expected = {"items":[{"type":["h-entry"],"lang":"se","properties":{"content":[{"lang":"en","value":"microformats.org at 7","html":"microformats.org at 7"}],"name":["microformats.org at 7"]}}],"rels":{},"rel-urls":{}};
+
+   it('lang', function(){
+       assert.deepEqual(found, expected);
+   });
+});


### PR DESCRIPTION
This is a test implementation of the brainstorm around parsing of languages at the Microformats wiki: http://microformats.org/wiki/microformats2-parsing-brainstorming#Parse_language_information

The tests are added here for now even though I know that they belong in a separate repository eventually if this brainstorm reaches a conclusion. For now its easier to keep it all in the same place.

For now this PR isn't ready to be merged but needs to await the conclusion of the brainstorm. Submitting it anyhow so there can be a place to discuss this experimental implementation.

This produces an output like what has been proposed in the wiki:

```json
{
  "type": ["h-entry"],
  "lang": "se",
  "properties": {
    "name": ["En svensk titel"],
    "content": [
      {
        "lang": "en",
        "html": "With an <em>english</em> summary",
        "value": "With an english summary"
      },
      {
        "html": "Och <em>svensk</em> huvudtext",
        "value": "Och svensk huvudtext"
      }
    ]
  }
}
```

For an input like:

```html
<div class="h-entry" lang="se">
  <h1 class="p-name">En svensk titel</h1>
  <div class="e-content" lang="en">With an <em>english</em> summary</div>
  <div class="e-content">Och <em>svensk</em> huvudtext</div>
</div>
```