### PR TITLE
Fix "npm install" example to mention right package

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Installation
 Using bower:
 
 ```sh
-$ npm install microformat-shiv
+$ npm install microformat-node
 ```
 
 Methods


### PR DESCRIPTION
It should be `npm install microformat-node`– right?

(Sorry for the change of the last line, GitHub's editor added that as an unintended bonus)