### PR TITLE
Document baseUrl option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Options
 * `html` - (String) the html to be parse
 * `node` - (Cheerio DOM object) the element to be parse
 * `filter` - (Array) microformats types returned - i.e. `['h-card']` - always adds `rels`
+* `baseUrl` - (String) a base URL to resolve any relative URL:s to
 * `textFormat` - (String) text style `whitespacetrimmed` or `normalised` default is `whitespacetrimmed`
 * `dateFormat` - (String) the ISO date profile `auto`, `microformat2`, `w3c` `rfc3339` or `html5` default is `auto`
 * `add` - (Array) adds microformat version 1 definitions


### PR DESCRIPTION
On my long overdue migration from `0.3.0` in [voxpelli/webpage-webmentions](https://github.com/voxpelli/webpage-webmentions) I at first thought that support for specifying a custom `baseUrl` for resolving relative URL:s was gone, but a quick search in the code revealed that it was actually still there.

I took the liberty of documenting that option so that others can more easily find it if they need it :)