### PR TITLE
Include microformat-shiv ^2.0.0 range from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "bluebird": "2.9.x",
     "cheerio": "0.19.x",
     "ent": "^2.2.0",
-    "microformat-shiv": "glennjones/microformat-shiv"
+    "microformat-shiv": "^2.0.0"
   },
   "devDependencies": {
     "hapi": "8.4.x",


### PR DESCRIPTION
Pulling down dependencies from GitHub should be avoided when possible and pointing a dependency on the master branch of another dependency makes it very hard to ever introduce any breaking changes in that other package without affecting all old releases of the first package.