### PR TITLE
Decode entities in attributes – solves &amp; showing in URL:s

### DIFF
--- a/lib/domutils.js
+++ b/lib/domutils.js
@@ -130,7 +130,8 @@ var Modules = (function (modules) {
 		* @return {String || null}
 		*/
 		getAttribute: function(node, attributeName) {
-			return this.$(node).attr(attributeName);
+			var value = this.$(node).attr(attributeName);
+			return value ? ent.decode(value) : value;
 		},
 
 
@@ -192,7 +193,7 @@ var Modules = (function (modules) {
 			var out = [],
 				attList;
 
-			attList = this.$(node).attr(attributeName);
+			attList = this.getAttribute(node, attributeName);
 			if(attList && attList !== '') {
 				if(attList.indexOf(' ') > -1) {
 					out = attList.split(' ');

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 /*
    microformat-node - v2.0.0
-   Built: 2016-05-27 06:05 - 
+   Built: 2016-07-11 12:07 - 
    Copyright (c) 2016 Glenn Jones
    Licensed MIT 
 */
@@ -2551,7 +2551,8 @@ var Modules = (function (modules) {
 		* @return {String || null}
 		*/
 		getAttribute: function(node, attributeName) {
-			return this.$(node).attr(attributeName);
+			var value = this.$(node).attr(attributeName);
+			return value ? ent.decode(value) : value;
 		},
 
 
@@ -2613,7 +2614,7 @@ var Modules = (function (modules) {
 			var out = [],
 				attList;
 
-			attList = this.$(node).attr(attributeName);
+			attList = this.getAttribute(node, attributeName);
 			if(attList && attList !== '') {
 				if(attList.indexOf(' ') > -1) {
 					out = attList.split(' ');

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "mocha-lcov-reporter": "0.0.x"
   },
   "scripts": {
-    "start": "app",
+    "start": "node app",
     "test": "make test",
     "coveralls": "./node_modules/.bin/mocha test -R mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js"
   }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   },
   "scripts": {
     "start": "node app",
+    "build": "node -e \"require('grunt').tasks(['default']);\"",
     "test": "make test",
     "coveralls": "./node_modules/.bin/mocha test -R mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js"
   }


### PR DESCRIPTION
As title says. While updating [voxpelli/webpage-webmentions](https://github.com/voxpelli/webpage-webmentions) to use the newest version of this library my tests showed some different output compared to the older version and while some were improvements this one was a regression: I now got `&amp;` in some of the URL:s.

Here's a PR that adds entity decoding to all attribute fetching so that no attribute based values can get entities into them.

I also added in a fix for `npm start` as the default one didn't work + I added a new `npm run build` command as I had a hard time finding how to build the code at first and having everything available as npm scripts makes for an easy place to look.