### PR TITLE
Drops bluebird as a dependency.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
-  - "6.0"
-  - "5.0"
+  - "8"
+  - "10"
+  - "12"
 after_success:
 - ./node_modules/.bin/jscoverage lib lib-cov
 - mv lib lib-orig

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 /*
-   microformat-node - v2.0.2
-   Built: 2017-05-31 09:05 - 
-   Copyright (c) 2017 Glenn Jones
+   microformat-node - v2.0.3
+   Built: 2019-10-29 01:10 - 
+   Copyright (c) 2019 Glenn Jones
    Licensed MIT 
 */
 
@@ -10,10 +10,10 @@
 var urlParser = require('url'),
 	ent = require('ent'),
 	cheerio = require('cheerio'),
-	Promise = require('bluebird');
+	util = require('util');
 
 var Modules = (function (modules) {
-	modules.version = '2.0.2';
+	modules.version = '2.0.3';
 	modules.livingStandard = '2016-05-25T09:22:18Z';
 
 	/**
@@ -4585,10 +4585,6 @@ var Modules = (function (modules) {
 } (Modules || {}));
 
 
-// Add promise versions of functions
-Modules = Promise.promisifyAll(Modules);
-
-
 // export for node
 module.exports = { 
     version: Modules.version,
@@ -4598,8 +4594,8 @@ module.exports = {
     isMicroformat: Modules.isMicroformat,
     hasMicroformats: Modules.hasMicroformats,
     // Promise versions
-    getAsync: Modules.getAsync,
-    countAsync: Modules.countAsync,
-    isMicroformatAsync: Modules.isMicroformatAsync,
-    hasMicroformatsAsync: Modules.hasMicroformatsAsync
+    getAsync: util.promisify(Modules.get),
+    countAsync: util.promisify(Modules.count),
+    isMicroformatAsync: util.promisify(Modules.isMicroformat),
+    hasMicroformatsAsync: util.promisify(Modules.hasMicroformats)
 }

--- a/lib/version.js
+++ b/lib/version.js
@@ -1,1 +1,1 @@
-	modules.version = '2.0.2';
+	modules.version = '2.0.3';

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "main": "index",
   "dependencies": {
-    "bluebird": "3.5.x",
     "cheerio": "0.22.x",
     "ent": "^2.2.0",
     "microformat-shiv": "^2.0.0"

--- a/wrap/wrap-end.js
+++ b/wrap/wrap-end.js
@@ -108,10 +108,6 @@
 } (Modules || {}));
 
 
-// Add promise versions of functions
-Modules = Promise.promisifyAll(Modules);
-
-
 // export for node
 module.exports = { 
     version: Modules.version,
@@ -121,8 +117,8 @@ module.exports = {
     isMicroformat: Modules.isMicroformat,
     hasMicroformats: Modules.hasMicroformats,
     // Promise versions
-    getAsync: Modules.getAsync,
-    countAsync: Modules.countAsync,
-    isMicroformatAsync: Modules.isMicroformatAsync,
-    hasMicroformatsAsync: Modules.hasMicroformatsAsync
+    getAsync: util.promisify(Modules.get),
+    countAsync: util.promisify(Modules.count),
+    isMicroformatAsync: util.promisify(Modules.isMicroformat),
+    hasMicroformatsAsync: util.promisify(Modules.hasMicroformats)
 }

--- a/wrap/wrap-start.js
+++ b/wrap/wrap-start.js
@@ -2,6 +2,6 @@
 var urlParser = require('url'),
 	ent = require('ent'),
 	cheerio = require('cheerio'),
-	Promise = require('bluebird');
+	util = require('util');
 
 var Modules = (function (modules) {


### PR DESCRIPTION
Since all maintained versions of Node (v8 and up) have built in promises and `util.promisify`, this PR drops bluebird in favour of those.